### PR TITLE
step-to-obj fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target
+*/target
 /Cargo.lock
 *.obj
 *.json

--- a/truck-stepio/examples/step-to-obj.rs
+++ b/truck-stepio/examples/step-to-obj.rs
@@ -9,13 +9,12 @@ fn main() {
         eprintln!("usage: step-to-obj <input step file> [output obj file]");
         return;
     } else if args.len() == 2 {
-        args.push("output.stp".to_string());
+        args.push("output.obj".to_string());
     }
 
     let step_file = std::fs::read_to_string(&args[1]).unwrap();
     let exchange = ruststep::parser::parse(&step_file).unwrap();
     let table = Table::from_data_section(&exchange.data[0]);
-
     let mut polymesh = PolygonMesh::default();
     table.shell.iter().for_each(|shell| {
         let shell = table.to_compressed_shell(&shell.1).unwrap();

--- a/truck-stepio/src/in/mod.rs
+++ b/truck-stepio/src/in/mod.rs
@@ -1615,7 +1615,6 @@ impl Table {
                     return None;
                 }
                 let len = eidx_map.len();
-                eidx_map.insert(idx, len);
                 let edge_curve = edge.clone().into_owned(self).ok()?;
                 let curve = edge_curve.parse_curve3d().ok()?;
                 let front = if let Ref(Name::Entity(idx)) = edge.edge_start {
@@ -1628,6 +1627,7 @@ impl Table {
                 } else {
                     return None;
                 };
+                eidx_map.insert(idx, len);
                 Some(CompressedEdge {
                     vertices: (front, back),
                     curve,
@@ -1660,14 +1660,13 @@ impl Table {
                         let edges: Vec<CompressedEdgeIndex> = bound
                             .edge_list
                             .iter()
-                            .enumerate()
-                            .filter_map(|(index, edge)| match edge {
+                            .filter_map(|edge| match edge {
                                 Ref(Name::Entity(idx)) => self
                                     .oriented_edge
                                     .get(idx)
                                     .and_then(|oriented_edge| {
-                                        //let idx = oriented_edge.edge_element_idx()?;
-                                        //let index = *eidx_map.get(&idx)?;
+                                        let idx = oriented_edge.edge_element_idx()?;
+                                        let index = *eidx_map.get(&idx)?;
                                         Some(CompressedEdgeIndex {
                                             index,
                                             orientation: oriented_edge.orientation,

--- a/truck-stepio/src/in/mod.rs
+++ b/truck-stepio/src/in/mod.rs
@@ -1660,13 +1660,14 @@ impl Table {
                         let edges: Vec<CompressedEdgeIndex> = bound
                             .edge_list
                             .iter()
-                            .filter_map(|edge| match edge {
+                            .enumerate()
+                            .filter_map(|(index, edge)| match edge {
                                 Ref(Name::Entity(idx)) => self
                                     .oriented_edge
                                     .get(idx)
                                     .and_then(|oriented_edge| {
-                                        let idx = oriented_edge.edge_element_idx()?;
-                                        let index = *eidx_map.get(&idx)?;
+                                        //let idx = oriented_edge.edge_element_idx()?;
+                                        //let index = *eidx_map.get(&idx)?;
                                         Some(CompressedEdgeIndex {
                                             index,
                                             orientation: oriented_edge.orientation,


### PR DESCRIPTION
Here's a few fixes I implemented while trying to get step importing to work:

* Git always attempted to add the */target folders to my commits, so I added it to the .gitignore.
* The step-to-obj example outputs a .stp file instead of an .obj. I changed that.
* triangulation.rs panicked when accessing edges on line 99. This was because the to_compressed_shell function writes an index to the boundaries vector that isn't necessarily a valid index for the edge vector. ~I enumerated the edges and added this index instead. I hope this is what was meant to happen in the code. It works for most of my .stp test cases, but I think I'll have to change the .or_else branch as well for it to function fully.~ This was because a new index was being added to the eidx_map even if the function could still return None in a filter_map within to_compressed_shell of Table. I moved adding a new index below all conditions potentially returning None.

Please let me know what you think and if you'd like any changes.