### PR TITLE
Fix typos in truck-topology

### DIFF
--- a/truck-topology/src/errors.rs
+++ b/truck-topology/src/errors.rs
@@ -13,7 +13,7 @@ pub enum Error {
     /// ```
     #[error("Two same vertices cannot construct an edge.")]
     SameVertex,
-    /// The empty wire cannot contruct a face.
+    /// The empty wire cannot construct a face.
     /// # Examples
     /// ```
     /// use truck_topology::*;

--- a/truck-topology/src/face.rs
+++ b/truck-topology/src/face.rs
@@ -148,7 +148,7 @@ impl<P, C, S> Face<P, C, S> {
     /// let boundaries = face.boundaries();
     /// face.invert();
     ///
-    /// // The result of face.boudnary() is already inversed.
+    /// // The result of face.boundary() is already inversed.
     /// assert_eq!(face.boundaries()[0], boundaries[0].inverse());
     ///
     /// // The absolute boundaries does never change.
@@ -214,7 +214,7 @@ impl<P, C, S> Face<P, C, S> {
     /// assert_eq!(face0.boundaries(), face1.boundaries());
     /// ```
     /// # Remarks
-    /// 1. If the face is inverted, then the added wire is inverted as absolute bounday.
+    /// 1. If the face is inverted, then the added wire is inverted as absolute boundary.
     /// ```
     /// use truck_topology::*;
     /// let v = Vertex::news(&[(), (), (), (), (), ()]);
@@ -235,7 +235,7 @@ impl<P, C, S> Face<P, C, S> {
     /// // The boundary is added in compatible with the face orientation.
     /// assert_eq!(face.boundaries()[1], wire1);
     ///
-    /// // The absolute bounday is inverted!
+    /// // The absolute boundary is inverted!
     /// let iter0 = face.absolute_boundaries()[1].edge_iter();
     /// let iter1 = wire1.edge_iter().rev();
     /// for (edge0, edge1) in iter0.zip(iter1) {
@@ -306,7 +306,7 @@ impl<P, C, S> Face<P, C, S> {
     /// assert_eq!(face0.boundaries(), face1.boundaries());
     /// ```
     /// # Remarks
-    /// 1. If the face is inverted, then the added wire is inverted as absolute bounday.
+    /// 1. If the face is inverted, then the added wire is inverted as absolute boundary.
     /// ```
     /// use truck_topology::*;
     /// let v = Vertex::news(&[(), (), (), (), (), ()]);
@@ -327,7 +327,7 @@ impl<P, C, S> Face<P, C, S> {
     /// // The boundary is added in compatible with the face orientation.
     /// assert_eq!(face.boundaries()[1], wire1);
     ///
-    /// // The absolute bounday is inverted!
+    /// // The absolute boundary is inverted!
     /// let iter0 = face.absolute_boundaries()[1].edge_iter();
     /// let iter1 = wire1.edge_iter().rev();
     /// for (edge0, edge1) in iter0.zip(iter1) {

--- a/truck-topology/src/lib.rs
+++ b/truck-topology/src/lib.rs
@@ -128,7 +128,7 @@ pub struct Wire<P, C> {
     edge_list: VecDeque<Edge<P, C>>,
 }
 
-/// Face, attatched to a simple and closed wire.
+/// Face, attached to a simple and closed wire.
 ///
 /// The constructors `Face::new()`, `Face::try_new()`, and `Face::new_unchecked()`
 /// create a different faces each time, even if the boundary wires are the same one.
@@ -242,7 +242,7 @@ pub type EdgeID<C> = ID<Mutex<C>>;
 /// ```
 pub type FaceID<S> = ID<Mutex<S>>;
 
-/// configuation for vertex display format.
+/// configuration for vertex display format.
 #[derive(Clone, Copy, Debug)]
 pub enum VertexDisplayFormat {
     /// Display all data like `Vertex { id: 0x123456789ab, entity: [0.0, 1.0] }`.
@@ -255,7 +255,7 @@ pub enum VertexDisplayFormat {
     AsPoint,
 }
 
-/// Configuation for edge display format.
+/// Configuration for edge display format.
 #[derive(Clone, Copy, Debug)]
 pub enum EdgeDisplayFormat {
     /// Display all data like `Edge { id: 0x123456789ab, vertices: (0, 1), entity: BSplineCurve {..} }`.
@@ -287,7 +287,7 @@ pub enum EdgeDisplayFormat {
     AsCurve,
 }
 
-/// Configuation for wire display format.
+/// Configuration for wire display format.
 #[derive(Clone, Copy, Debug)]
 pub enum WireDisplayFormat {
     /// Display tuple struct of edge list like `Wire([Edge {..}, Edge {..}, ..])`.
@@ -307,7 +307,7 @@ pub enum WireDisplayFormat {
     },
 }
 
-/// Configuation for face display format
+/// Configuration for face display format
 #[derive(Clone, Copy, Debug)]
 pub enum FaceDisplayFormat {
     /// Display all data like `Face { id: 0x123456789ab, boundaries: [Wire(..), Wire(..)], entity: BSplineSurface {..} }`.
@@ -339,7 +339,7 @@ pub enum FaceDisplayFormat {
     AsSurface,
 }
 
-/// Configuation for shell display format
+/// Configuration for shell display format
 #[derive(Clone, Copy, Debug)]
 pub enum ShellDisplayFormat {
     /// Display as faces list tuple struct like `Shell([Face {..}, Face {..}, ..])`.
@@ -354,7 +354,7 @@ pub enum ShellDisplayFormat {
     },
 }
 
-/// Configuation for solid display format
+/// Configuration for solid display format
 #[derive(Clone, Copy, Debug)]
 pub enum SolidDisplayFormat {
     /// Display solid struct like `Solid { boundaries: [Shell(..), Shell(..), ..] }`.

--- a/truck-topology/src/shell.rs
+++ b/truck-topology/src/shell.rs
@@ -135,7 +135,7 @@ impl<P, C, S> Shell<P, C, S> {
     ///
     /// For the returned hashmap `map` and each vertex `v`,
     /// the vector `map[&v]` cosists all vertices which is adjacent to `v`.
-    /// # Exmaples
+    /// # Examples
     /// ```
     /// use truck_topology::*;
     /// use std::collections::HashSet;

--- a/truck-topology/tests/large-solid-torus.rs
+++ b/truck-topology/tests/large-solid-torus.rs
@@ -47,7 +47,7 @@ fn main() {
     large_torus();
     let end_time = instant.elapsed();
     println!(
-        "excute time: {}.{:03} sec",
+        "execute time: {}.{:03} sec",
         end_time.as_secs(),
         end_time.subsec_millis(),
     );


### PR DESCRIPTION
Found via `codespell -q 3 -L ans,crate`