### PR TITLE
Fix creation error of `Instance` on macOS Sonoma

### DIFF
--- a/truck-platform/src/scene.rs
+++ b/truck-platform/src/scene.rs
@@ -14,12 +14,13 @@ async fn init_default_device(
     window: Option<Arc<Window>>,
 ) -> (DeviceHandler, Option<WindowHandler>) {
     #[cfg(not(feature = "webgl"))]
-    let instance = Instance::new(InstanceDescriptor {
-        backends: Backends::PRIMARY,
-        dx12_shader_compiler: Default::default(),
-    });
+    let backends = Backends::PRIMARY;
     #[cfg(feature = "webgl")]
-    let instance = Instance::new(Backends::all());
+    let backends = Backends::all();
+    let instance = Instance::new(InstanceDescriptor {
+        backends,
+        ..Default::default()
+    });
 
     // trust winit
     #[allow(unsafe_code)]


### PR DESCRIPTION
When I run `wgsl-sandbox` example on macOS Sonoma beta3,  it caused the following error:

```log
   Compiling truck-platform v0.5.0 (/Users/lijinlei/Rust/forks/truck/truck-platform)
error[E0308]: mismatched types
    --> truck-platform/src/scene.rs:22:34
     |
22   |     let instance = Instance::new(Backends::all());
     |                    ------------- ^^^^^^^^^^^^^^^ expected `InstanceDescriptor`, found `Backends`
     |                    |
     |                    arguments to this function are incorrect
     |
note: associated function defined here
    --> /Users/lijinlei/.cargo/registry/src/index.crates.io-6f17d22bba15001f/wgpu-0.16.3/src/lib.rs:1331:12
```