### PR TITLE
Update wgpu to v0.17

### DIFF
--- a/truck-platform/Cargo.toml
+++ b/truck-platform/Cargo.toml
@@ -22,7 +22,7 @@ derive_more = "0.99.17"
 futures-intrusive = "0.5.0"
 rustc-hash = "1.1.0"
 truck-base = { version = "0.4.0", path = "../truck-base" }
-wgpu = "0.16.2"
+wgpu = "0.17.0"
 winit = "0.28.6"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
@@ -35,7 +35,7 @@ web-sys = "0.3.64"
 image = "0.24.6"
 rayon = "1.7.0"
 env_logger = "0.10.0"
-naga = { version = "0.12.3", features = ["wgsl-in"] }
+naga = { version = "0.13.0", features = ["wgsl-in"] }
 pollster = "0.3.0"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]

--- a/truck-platform/src/lib.rs
+++ b/truck-platform/src/lib.rs
@@ -126,7 +126,7 @@ pub struct BufferHandler {
 pub struct PreBindGroupLayoutEntry {
     pub visibility: ShaderStages,
     pub ty: BindingType,
-    pub count: Option<core::num::NonZeroU32>,
+    pub count: Option<std::num::NonZeroU32>,
 }
 
 /// A collection of GPU buffers used by `wgpu` for rendering


### PR DESCRIPTION
The wgpu v0.17 does not involve any API changes.  I have tested all the examples in the `truck`, and they all run smoothly.





