### PR TITLE
Fix `rsweep` handling of partial negative angles.

### DIFF
--- a/truck-modeling/src/builder.rs
+++ b/truck-modeling/src/builder.rs
@@ -631,12 +631,11 @@ pub fn rsweep<T: ClosedSweep<Point3, Curve, Surface>, R: Into<Rad<f64>>>(
 ) -> T::Swept {
     debug_assert!(axis.magnitude().near(&1.0));
     let angle = angle.into();
-    if angle.0.abs() < 2.0 * PI.0 {
-        partial_rsweep(elem, origin, axis, angle)
-    } else if angle.0 > 0.0 {
-        whole_rsweep(elem, origin, axis)
+    let sign = if angle.0 < 0.0 { -1.0 } else { 1.0 };
+    if angle.0.abs() >= 2.0 * PI.0 {
+        whole_rsweep(elem, origin, sign * axis)
     } else {
-        whole_rsweep(elem, origin, -axis)
+        partial_rsweep(elem, origin, sign * axis, angle * sign)
     }
 }
 


### PR DESCRIPTION
I believe the current rsweep code is incorrect when using negative angles less than a full rotation.

This example code:

```rust
let vertex = builder::vertex(Point3::new(1.0, 0.0, 0.0));
let circle = builder::rsweep(&vertex, Point3::origin(), Vector3::unit_z(), Rad(7.0));
let circle = translated(&circle, 2.0 * Vector3::unit_x());
let disk = builder::try_attach_plane(&vec![circle]).unwrap();
let solid = builder::rsweep(&disk, Point3::origin(), Vector3::unit_y(), -Rad(1.0));

render_to("foo.obj", solid);
```
yields a full torus even though the sweep angle is only -1 radian:

<img width="545" alt="Screen Shot 2024-04-06 at 11 55 40 AM" src="https://github.com/ricosjp/truck/assets/147919/d82a24b4-d793-4e04-8dcb-88dd95c3e795">

This commit changes the conditional so that:

- `whole_sweep` is always called when the absolute value of the angle is 2 Pi or greater
- `partial_sweep` is always given a positive angle

In both cases negative input angles are handled by inverting the rotation axis.

After this commit, the code above yields a non-inverted object:

<img width="448" alt="Screen Shot 2024-04-06 at 11 55 11 AM" src="https://github.com/ricosjp/truck/assets/147919/be8e1001-e989-43e5-9351-e2b6cda209ed">

I wasn't sure the best way to add a test, but if you tell me how you'd like to do it I can add an additional commit to this PR.
My best idea is to do the partial sweep with negative angle and check that the resulting solid's mesh is closed, but I don't know if meshing is perhaps too expensive to add in the test suite and another approach would be preferred.
