### PR TITLE
Handle Axis2Placement parallel to x-axis without reference

### DIFF
--- a/truck-stepio/src/in/mod.rs
+++ b/truck-stepio/src/in/mod.rs
@@ -845,7 +845,11 @@ impl From<&Axis2Placement3d> for Matrix4 {
         };
         let x = match &axis.ref_direction {
             Some(axis) => Vector3::from(axis),
-            None => Vector3::unit_x(),
+            // may can cause a vector of length 0 later, if z is parallel to x
+            None => match z.near(&Vector3::unit_x()) { 
+                true => Vector3::unit_y(),
+                false => Vector3::unit_x(),
+            },
         };
         let x = (x - x.dot(z) * z).normalize();
         let y = z.cross(x);


### PR DESCRIPTION
Hi,
first thank you for your great work, I really enjoy playing around with it in some little projects so far.

This is also how I stumbled over an untested case in the stepio crate, which caused some trouble. The cause is an AxisPlacement which is parallel to the global x-axis and also no reference is given for the AxisPlacement. The solution is more or less trivial, by just avoiding the artificial reference axis being parallel to the actual axis. Choosing the y-axis instead resolved the issue.

I adopted the existing tests for verification. I'm not really sure if the solution of the issue and tests meet your expectations, there are definitely other possible solutions.