### PR TITLE
Fix syntax error when reading binary STL > 8192b.

### DIFF
--- a/truck-polymesh/src/stl.rs
+++ b/truck-polymesh/src/stl.rs
@@ -149,14 +149,10 @@ fn ascii_one_read<R: BufRead>(lines: &mut Lines<R>) -> Result<Option<StlFace>> {
 
 fn binary_one_read<R: Read>(reader: &mut R) -> Result<Option<StlFace>> {
     let mut chunk = [0; CHUNKSIZE];
-    let size = reader.read(&mut chunk)?;
-    if size == CHUNKSIZE {
-        let mut buf = [0; FACESIZE];
-        buf.copy_from_slice(&chunk[..FACESIZE]);
-        Ok(Some(bytemuck::cast(buf)))
-    } else {
-        Err(syntax_error().into())
-    }
+    reader.read_exact(&mut chunk)?;
+    let mut buf = [0; FACESIZE];
+    buf.copy_from_slice(&chunk[..FACESIZE]);
+    Ok(Some(bytemuck::cast(buf)))
 }
 
 /// Write STL file in `stl_type` format.


### PR DESCRIPTION
The code was using read() to read 50 bytes at a time, but when passed a BufReader, BufReader::read() will return fewer bytes than requested when the internal buffer contains fewer bytes. Since the default buffer is 8192 bytes, which is not divisible by 50 (after reading the header), the code would always get an 8-byte read after 8192 bytes of data and throw a syntax error. Using read_exact() instead fixes the problem.