### PR TITLE
Fix for Issue #91: Boolean Operations with STEP Geometry Types

### DIFF
--- a/truck-stepio/src/in/step_geometry/geom_impls.rs
+++ b/truck-stepio/src/in/step_geometry/geom_impls.rs
@@ -1,5 +1,14 @@
 use super::*;
 
+impl From<IntersectionCurve<BSplineCurve<Point3>, Surface, Surface>> for Curve3D {
+    fn from(ic: IntersectionCurve<BSplineCurve<Point3>, Surface, Surface>) -> Self {
+        // Extract the B-spline curve from the intersection curve
+        // The intersection curve stores the approximating B-spline as its leader
+        let (_, _, leader) = ic.destruct();
+        Curve3D::BSplineCurve(leader)
+    }
+}
+
 impl ToSameGeometry<Curve3D> for Line<Point3> {
     #[inline]
     fn to_same_geometry(&self) -> Curve3D { Curve3D::Line(*self) }

--- a/truck-stepio/tests/input/main.rs
+++ b/truck-stepio/tests/input/main.rs
@@ -1,4 +1,5 @@
 mod assy;
 mod geometry;
+mod shapeops_with_step;
 mod table;
 mod tessellate_shape;

--- a/truck-stepio/tests/input/shapeops_with_step.rs
+++ b/truck-stepio/tests/input/shapeops_with_step.rs
@@ -1,0 +1,76 @@
+//! Test boolean operations with STEP geometry types
+//! This test reproduces and fixes issue #91
+//!
+//! Issue #91: Boolean operations with STEP-loaded solids failed because Curve3D
+//! didn't implement the required From<IntersectionCurve<...>> trait.
+
+use truck_stepio::r#in::step_geometry::{Curve3D, Surface};
+
+/// This test verifies that the trait bound `Curve3D: ShapeOpsCurve<Surface>` is satisfied.
+/// Before the fix, this would fail to compile with:
+/// ```text
+/// error[E0277]: the trait bound `Curve3D: ShapeOpsCurve<Surface>` is not satisfied
+/// = help: the trait `From<IntersectionCurve<BSplineCurve<Point3>, Surface, Surface>>`
+///         is not implemented for `Curve3D`
+/// ```
+#[test]
+fn test_curve3d_implements_shapeops_trait() {
+    // This test ensures that the trait bounds are satisfied.
+    // We don't actually need to run a full boolean operation - just checking
+    // that the code compiles proves that Curve3D implements ShapeOpsCurve<Surface>.
+
+    // The key trait requirement is:
+    // From<IntersectionCurve<BSplineCurve<Point3>, Surface, Surface>> for Curve3D
+
+    // We can verify this by creating a simple type check:
+    fn _type_check_shapeops_curve<
+        C: truck_shapeops::ShapeOpsCurve<Surface>,
+        S: truck_shapeops::ShapeOpsSurface,
+    >() {
+    }
+
+    // If Curve3D didn't implement the trait, this would fail to compile:
+    _type_check_shapeops_curve::<Curve3D, Surface>();
+}
+
+/// Verify the From implementation works correctly
+#[test]
+fn test_intersection_curve_to_curve3d_conversion() {
+    use truck_modeling::{BSplineCurve, IntersectionCurve, Plane, Point3};
+    use truck_stepio::r#in::step_geometry::ElementarySurface;
+
+    // Create a simple B-spline curve
+    let knot_vec = truck_modeling::KnotVec::from(vec![0.0, 0.0, 1.0, 1.0]);
+    let control_points = vec![Point3::new(0.0, 0.0, 0.0), Point3::new(1.0, 1.0, 0.0)];
+    let bspline = BSplineCurve::new(knot_vec, control_points);
+
+    // Create two planes
+    let plane1 = Plane::new(
+        Point3::new(0.0, 0.0, 0.0),
+        Point3::new(1.0, 0.0, 0.0),
+        Point3::new(0.0, 1.0, 0.0),
+    );
+    let plane2 = Plane::new(
+        Point3::new(0.0, 0.0, 1.0),
+        Point3::new(1.0, 0.0, 1.0),
+        Point3::new(0.0, 1.0, 1.0),
+    );
+
+    // Create surfaces from planes
+    let surf1 = Surface::ElementarySurface(ElementarySurface::Plane(plane1));
+    let surf2 = Surface::ElementarySurface(ElementarySurface::Plane(plane2));
+
+    // Create an intersection curve
+    let intersection = IntersectionCurve::new(surf1, surf2, bspline);
+
+    // Convert to Curve3D - this is what the From implementation does
+    let curve3d: Curve3D = intersection.into();
+
+    // Verify it's a BSplineCurve variant
+    match curve3d {
+        Curve3D::BSplineCurve(_) => {
+            // Success! The conversion worked correctly
+        }
+        _ => panic!("Expected BSplineCurve variant"),
+    }
+}


### PR DESCRIPTION
# Fix for Issue #91: Boolean Operations with STEP Geometry Types

## Problem

When attempting to perform boolean operations (AND/OR) on solids loaded from STEP files, compilation failed with:

```
error[E0277]: the trait bound `Curve3D: ShapeOpsCurve<Surface>` is not satisfied
  = help: the trait `From<IntersectionCurve<BSplineCurve<Point3>, Surface, Surface>>`
          is not implemented for `Curve3D`
```

## Root Cause

The `truck-shapeops` crate requires that curve types implement `ShapeOpsCurve`, which mandates:

```rust
From<IntersectionCurve<BSplineCurve<Point3>, S, S>>
```

During boolean operations, intersection curves are created between surfaces and need to be converted back into the solid's curve type. `Curve3D` (used for STEP geometry) was missing this critical conversion, making it impossible to use STEP-loaded solids in boolean operations.

## Solution

Added a single `From` implementation in `truck-stepio/src/in/step_geometry/geom_impls.rs`:

```rust
impl From<IntersectionCurve<BSplineCurve<Point3>, Surface, Surface>> for Curve3D {
    fn from(ic: IntersectionCurve<BSplineCurve<Point3>, Surface, Surface>) -> Self {
        // Extract the B-spline curve from the intersection curve
        // The intersection curve stores the approximating B-spline as its leader
        let (_, _, leader) = ic.destruct();
        Curve3D::BSplineCurve(leader)
    }
}
```

This extracts the B-spline approximation from the intersection curve and wraps it in a `Curve3D` enum variant. The two surfaces are discarded since they're not needed—only the geometric curve representation is required.

## Testing

Added comprehensive tests in `truck-stepio/tests/input/shapeops_with_step.rs`:

1. **Compile-time trait verification**: Confirms `Curve3D` now satisfies `ShapeOpsCurve<Surface>` bounds
2. **Conversion test**: Validates the `From` implementation correctly extracts and wraps the B-spline curve

✅ Both tests pass successfully