### PR TITLE
feat(truck-js): add extrude/revolve aliases for tsweep/rsweep

### DIFF
--- a/truck-js/src/builder.rs
+++ b/truck-js/src/builder.rs
@@ -137,6 +137,12 @@ pub fn tsweep(shape: &AbstractShape, vector: &[f64]) -> AbstractShape {
     derive_all_sweepable!(shape, builder::tsweep, (vector))
 }
 
+/// Alias for [`tsweep`]: extrudes a shape along a vector.
+///
+/// Provided for discoverability — `extrude` is the standard term in most CAD APIs.
+#[wasm_bindgen]
+pub fn extrude(shape: &AbstractShape, vector: &[f64]) -> AbstractShape { tsweep(shape, vector) }
+
 /// Sweeps a vertex, an edge, a wire, a face, or a shell by the rotation.
 #[wasm_bindgen]
 pub fn rsweep(
@@ -148,4 +154,18 @@ pub fn rsweep(
 ) -> AbstractShape {
     intopt!(Point3, origin, Vector3, axis);
     derive_all_sweepable!(shape, builder::rsweep, (origin, axis, Rad(angle), division))
+}
+
+/// Alias for [`rsweep`]: revolves a shape around an axis.
+///
+/// Provided for discoverability — `revolve` is the standard term in most CAD APIs.
+#[wasm_bindgen]
+pub fn revolve(
+    shape: &AbstractShape,
+    origin: &[f64],
+    axis: &[f64],
+    angle: f64,
+    division: usize,
+) -> AbstractShape {
+    rsweep(shape, origin, axis, angle, division)
 }


### PR DESCRIPTION
Adds `extrude()` and `revolve()` as `#[wasm_bindgen]` aliases for `tsweep()` and `rsweep()` in `truck-js`.

## Motivation

`tsweep` and `rsweep` are truck-internal shorthand. JavaScript/TypeScript consumers coming from Onshape, FreeCAD, OpenCascade, or CadQuery will search for `extrude` and `revolve` — the universally understood CAD terms — and not find them.

## Changes

- `extrude(shape, vector)` → delegates to `tsweep`
- `revolve(shape, origin, axis, angle, division)` → delegates to `rsweep`
- Both `tsweep`/`rsweep` preserved for backwards compatibility
- Docstrings cross-reference each alias to its canonical function

## Notes

This is a pure alias addition — no logic change, no risk of breakage. The same change exists in the [monstertruck](https://github.com/virtualritz/monstertruck) fork at [`monstertruck-wasm/src/builder.rs L135`](https://github.com/virtualritz/monstertruck/blob/682c67622b4a04863fc4151c63ddcd07c6b4bb69/monstertruck-wasm/src/builder.rs#L135).

Closes #119