### PR TITLE
Write an intersection curve's second surface at its own index

### DIFF
--- a/truck-stepio/src/out/geometry.rs
+++ b/truck-stepio/src/out/geometry.rs
@@ -402,7 +402,7 @@ where
         ))?;
         self.leader().fmt(curve_idx, f)?;
         self.surface0().fmt(surface0_idx, f)?;
-        self.surface1().fmt(surface0_idx, f)
+        self.surface1().fmt(surface1_idx, f)
     }
 }
 

--- a/truck-stepio/tests/output/geometry.rs
+++ b/truck-stepio/tests/output/geometry.rs
@@ -367,3 +367,59 @@ fn geometry() {
     13
     );
 }
+
+#[test]
+fn intersection_curve() {
+    // Each part of an intersection curve must be written at its own index. The
+    // second surface used to be written at the first one's, overwriting it and
+    // spilling into the ids reserved for itself.
+    //
+    // The two surfaces are deliberately different sizes -- a B-spline of length
+    // 7 and a plane of length 5 -- so that `surface1_idx` has to be reached by
+    // adding the *first* surface's length. Two surfaces of equal length would
+    // let that arithmetic be wrong and still pass.
+    let leader =
+        truck_polymesh::PolylineCurve(vec![Point3::new(0.0, 0.0, 0.0), Point3::new(1.0, 0.0, 0.0)]);
+    let surface0 = BSplineSurface::new(
+        (KnotVec::bezier_knot(1), KnotVec::bezier_knot(2)),
+        vec![
+            vec![
+                Point3::new(0.0, 0.0, 0.0),
+                Point3::new(0.0, 1.0, 0.0),
+                Point3::new(0.0, 2.0, 0.0),
+            ],
+            vec![
+                Point3::new(1.0, 0.0, 0.0),
+                Point3::new(1.0, 1.0, 0.0),
+                Point3::new(1.0, 2.0, 0.0),
+            ],
+        ],
+    );
+    let surface1 = Plane::new(
+        Point3::new(0.0, 0.0, 0.0),
+        Point3::new(1.0, 0.0, 0.0),
+        Point3::new(0.0, 0.0, 1.0),
+    );
+    step_test::<
+        IntersectionCurve<truck_polymesh::PolylineCurve<Point3>, BSplineSurface<Point3>, Plane>,
+    >(
+        IntersectionCurve::new(surface0, surface1, leader),
+        "#1 = INTERSECTION_CURVE('', #2, (#5, #12), .CURVE_3D.);
+#2 = POLYLINE('', (#3, #4));
+#3 = CARTESIAN_POINT('', (0.0, 0.0, 0.0));
+#4 = CARTESIAN_POINT('', (1.0, 0.0, 0.0));
+#5 = B_SPLINE_SURFACE_WITH_KNOTS('', 1, 2, ((#6, #7, #8), (#9, #10, #11)), .UNSPECIFIED., .U., .U., .U., (2, 2), (3, 3), (0.0, 1.0), (0.0, 1.0), .UNSPECIFIED.);
+#6 = CARTESIAN_POINT('', (0.0, 0.0, 0.0));
+#7 = CARTESIAN_POINT('', (0.0, 1.0, 0.0));
+#8 = CARTESIAN_POINT('', (0.0, 2.0, 0.0));
+#9 = CARTESIAN_POINT('', (1.0, 0.0, 0.0));
+#10 = CARTESIAN_POINT('', (1.0, 1.0, 0.0));
+#11 = CARTESIAN_POINT('', (1.0, 2.0, 0.0));
+#12 = PLANE('', #13);
+#13 = AXIS2_PLACEMENT_3D('', #14, #15, #16);
+#14 = CARTESIAN_POINT('', (0.0, 0.0, 0.0));
+#15 = DIRECTION('', (0.0, -1.0, 0.0));
+#16 = DIRECTION('', (1.0, 0.0, 0.0));\n",
+        16,
+    );
+}


### PR DESCRIPTION
`DisplayByStep for IntersectionCurve` computes `surface1_idx` and then writes
`surface1` at `surface0_idx`:

```rust
let surface1_idx = surface0_idx + self.surface0().step_length();
...
self.surface0().fmt(surface0_idx, f)?;
self.surface1().fmt(surface0_idx, f)
```

So the second surface overwrites the first and spills past it into the ids
reserved for itself. Entities end up defined twice, and the reference the
`INTERSECTION_CURVE` entity makes to its second surface resolves to whatever
landed at that index — in a file I have here, a `CARTESIAN_POINT` where a
surface is required.

Exporting a solid produced by `truck-shapeops` is enough to hit it. A plate with
one bore comes out with 30 of its 488 entities defined twice.

`step_length` already accounted for both surfaces, so only the write needed
moving.

## Test

None of the shapes in `resources/shape` contain an intersection curve — they are
pre-baked `CompressedSolid`s whose curves are lines and B-splines — so no
existing test reaches this path. The added test constructs one directly, in the
style of the others.

Its two surfaces are deliberately different sizes, a B-spline of length 7 and a
plane of length 5, so that reaching `surface1_idx` requires adding the *first*
surface's length. Two surfaces of equal length would let that arithmetic be
wrong and still pass. The test fails both when `surface1` is written at
`surface0_idx` and when `surface1_idx` is computed from the wrong length.

The package list from `Makefile.toml`'s `cpu-test`: **660 passed, 0 failed.**
